### PR TITLE
Fix JSON serialization crash and ImageFolder errors

### DIFF
--- a/train.py
+++ b/train.py
@@ -262,6 +262,8 @@ def main():
         try:
             return x.item()
         except Exception:
+            if hasattr(x, 'dtype'):  # numpy types
+                return x.item() if hasattr(x, 'item') else float(x)
             return float(x) if isinstance(x, (int, float)) else x
     
     results = {

--- a/train_ann_baseline.py
+++ b/train_ann_baseline.py
@@ -224,8 +224,8 @@ def main():
     
     os.makedirs('results', exist_ok=True)
     
-    from torchvision import datasets
-    temp_dataset = datasets.ImageFolder(root=dataset_path)
+    from src.custom_imagefolder import SafeImageFolder
+    temp_dataset = SafeImageFolder(root=dataset_path)
     class_names = temp_dataset.classes
     num_classes = len(class_names)
     

--- a/visualize_results.py
+++ b/visualize_results.py
@@ -8,7 +8,8 @@ import seaborn as sns
 from sklearn.metrics import confusion_matrix, classification_report
 from collections import Counter
 import torch
-from torchvision import datasets, transforms
+from torchvision import transforms
+from src.custom_imagefolder import SafeImageFolder as ImageFolder
 from torch.utils.data import DataLoader
 import random
 
@@ -48,7 +49,7 @@ def analyze_dataset():
         transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD)
     ])
     
-    dataset = datasets.ImageFolder(root=DATASET_PATH, transform=transform)
+    dataset = ImageFolder(root=DATASET_PATH, transform=transform)
     
     class_counts = Counter()
     for _, label in dataset.samples:
@@ -114,7 +115,8 @@ def generate_sample_grid(dataset):
         plt.subplot(4, 4, i + 1)
         
         img_path, label = dataset.samples[sample_idx]
-        img = datasets.folder.default_loader(img_path)
+        from PIL import Image
+        img = Image.open(img_path).convert('RGB')
         img = transforms.Resize((IMAGE_SIZE, IMAGE_SIZE))(img)
         
         plt.imshow(img)


### PR DESCRIPTION
- Improve _to_py() function in train.py to handle numpy int64 types properly
- Replace all remaining datasets.ImageFolder with SafeImageFolder imports
- Fix PIL image loading in visualize_results.py to avoid undefined datasets reference
- Ensure all scripts use SafeImageFolder to prevent 'splits' directory errors